### PR TITLE
Add comprehensive documentation for entities and trip history

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,34 +193,41 @@ To use the example dashboard, install these HACS frontend integrations:
 
 ## 📱 Entities Created
 
-Once configured, the integration creates the following entities:
+Once configured, the integration creates **39+ entities** organized into several categories:
 
-### Numbers
+### Quick Summary
+
+| Category | Count | Description |
+|----------|-------|-------------|
+| **Numbers** | 11 | Trip metrics, odometer, battery tracking |
+| **Sensors** | 23+ | Energy, costs, battery health, statistics |
+| **DateTimes** | 4 | Trip timestamps and pause tracking |
+| **Switch** | 1 | Manual trip stop control |
+
+### Main Entities
+
+**Trip Tracking:**
 - `number.scooter_odo_debut` / `number.scooter_odo_fin` - Trip odometer start/end
 - `number.scooter_battery_soc_debut` / `number.scooter_battery_soc_fin` - Battery level start/end
-- `number.scooter_last_trip_distance` - Last trip distance
-- `number.scooter_last_trip_duration` - Last trip duration
-- `number.scooter_last_trip_avg_speed` / `max_speed` - Speed statistics
-- And more... (see [ENTITIES.md](docs/ENTITIES.md) for complete list)
+- `datetime.scooter_start_time` / `datetime.scooter_end_time` - Trip timestamps
+- `sensor.scooter_last_trip_distance` - Last trip distance
+- `sensor.scooter_last_trip_duration` - Last trip duration
+- `sensor.scooter_last_trip_avg_speed` / `max_speed` - Speed statistics
 
-### Sensors
-- `sensor.scooter_energy_consumption` - Total energy consumption
+**Energy & Costs:**
+- `sensor.scooter_energy_consumption` - Total energy consumption (kWh)
 - `sensor.scooter_energy_consumption_daily/weekly/monthly/yearly` - Utility meters
-- `sensor.scooter_energy_cost_*` - Energy cost sensors
-- `sensor.scooter_trips_history` - Trip history with JSON attributes
-- `sensor.scooter_battery_health` - Battery health metrics
-- And more...
+- `sensor.scooter_energy_cost_daily/weekly/monthly/yearly` - Energy cost sensors
 
-### DateTime
-- `datetime.scooter_start_time` / `end_time` - Trip timestamps
-- `datetime.scooter_last_moving_time` - Last movement timestamp
-- `datetime.scooter_pause_start` - Pause detection
+**Battery Health:**
+- `sensor.scooter_battery_cell_imbalance` - Cell voltage difference (mV)
+- `sensor.scooter_battery_soc_calculated` - Voltage-based SOC
+- `sensor.scooter_battery_charge_cycles` - Total charge cycles
 
-### Switch
+**Controls:**
 - `switch.stop_trip_now` - Manual trip stop button
 
-### Timer
-- `timer.scooter_stop_trip_tolerance` - Pause tolerance timer (auto-created)
+> **📖 See the complete list:** [ENTITIES.md](docs/ENTITIES.md)
 
 ## 🔄 How It Works
 
@@ -306,11 +313,12 @@ history.json + HA State Machine
 
 ## 📚 Documentation
 
-- [Installation Guide](docs/INSTALLATION.md)
-- [Configuration Options](docs/CONFIGURATION.md)
-- [Entity Reference](docs/ENTITIES.md)
-- [Debugging Guide](docs/DEBUGGING.md)
-- [FAQ](docs/FAQ.md)
+- [Installation Guide](INSTALLATION.md) - Step-by-step setup instructions
+- [Configuration Options](docs/CONFIGURATION.md) - Detailed configuration parameters
+- [Entity Reference](docs/ENTITIES.md) - **Complete list of all 39+ entities**
+- [Trip History Structure](docs/HISTORY.md) - **Understanding the history.json file**
+- [Debugging Guide](docs/DEBUGGING.md) - Troubleshooting and logging
+- [FAQ](docs/FAQ.md) - Frequently asked questions
 
 ## 🙏 Credits
 

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -1,0 +1,172 @@
+# Entités exposées par l'intégration
+
+Cette page documente toutes les entités créées par l'intégration Silence Scooter.
+
+## Table des matières
+
+- [Numbers (11 entités)](#numbers-11-entités)
+- [DateTimes (4 entités)](#datetimes-4-entités)
+- [Switch (1 entité)](#switch-1-entité)
+- [Sensors (23+ entités)](#sensors-23-entités)
+  - [Trigger Sensors (5)](#trigger-sensors)
+  - [Template Sensors (6)](#template-sensors)
+  - [Energy Cost Sensors (4)](#energy-cost-sensors)
+  - [Battery Health Sensors (4)](#battery-health-sensors)
+  - [Usage Statistics Sensors (3)](#usage-statistics-sensors)
+  - [Utility Meters (4)](#utility-meters)
+  - [Writable Sensors (3)](#writable-sensors)
+
+---
+
+## Numbers (11 entités)
+
+Ces entités de type `number` stockent des valeurs numériques pour le suivi des trajets et statistiques.
+
+| Entity ID | Nom | Min | Max | Step | Unité | Description |
+|-----------|-----|-----|-----|------|-------|-------------|
+| `number.scooter_pause_duration` | Durée totale des pauses | 0 | 1440 | 0.1 | minutes | Durée cumulée des pauses pendant le trajet actif |
+| `number.scooter_odo_debut` | Odomètre début de trajet | 0 | 100000 | 0.1 | km | Valeur de l'odomètre au début du trajet |
+| `number.scooter_odo_fin` | Odomètre fin de trajet | 0 | 100000 | 0.1 | km | Valeur de l'odomètre à la fin du trajet |
+| `number.scooter_battery_soc_debut` | Batterie SOC début de trajet | 0 | 100 | 0.1 | % | Niveau de batterie au début du trajet |
+| `number.scooter_battery_soc_fin` | Batterie SOC fin de trajet | 0 | 100 | 0.1 | % | Niveau de batterie à la fin du trajet |
+| `number.scooter_tracked_distance` | Distance suivie (manuel) | 0 | 100000 | 0.1 | km | Distance cumulée suivie manuellement |
+| `number.scooter_tracked_battery_used` | Batterie suivie (manuel) | 0 | 10000 | 0.1 | % | Batterie cumulée consommée suivie manuellement |
+| `number.scooter_energy_consumption_base` | Base consommation énergie scooter | 0 | 1000 | 0.001 | kWh | Valeur de base pour le calcul de consommation énergétique |
+| `number.scooter_last_trip_distance` | Distance du dernier trajet | 0 | 500 | 0.1 | km | Distance parcourue lors du dernier trajet |
+| `number.scooter_last_trip_duration` | Durée du dernier trajet | 0 | 1440 | 0.1 | min | Durée (nette des pauses) du dernier trajet |
+| `number.scooter_last_trip_battery_consumption` | Batterie consommée du dernier trajet | 0 | 100 | 0.1 | % | Batterie consommée lors du dernier trajet |
+
+---
+
+## DateTimes (4 entités)
+
+Ces entités stockent des horodatages pour la gestion des trajets.
+
+| Entity ID | Nom | Description |
+|-----------|-----|-------------|
+| `datetime.scooter_start_time` | Scooter Heure de départ dernier trajet | Horodatage du début du trajet actif/dernier trajet |
+| `datetime.scooter_end_time` | Scooter Heure de fin du dernier trajet | Horodatage de fin du trajet (1970-01-01 si trajet en cours) |
+| `datetime.scooter_last_moving_time` | Dernier instant en mouvement | Dernier moment où le scooter était en mouvement |
+| `datetime.scooter_pause_start` | Début de la pause | Horodatage du début de la pause en cours |
+
+> **Note**: Lorsqu'un trajet est en cours, `datetime.scooter_end_time` est mis à "1970-01-01 00:00:00" pour indiquer qu'il n'y a pas encore de fin.
+
+---
+
+## Switch (1 entité)
+
+| Entity ID | Nom | Description |
+|-----------|-----|-------------|
+| `switch.stop_trip_now` | Arrêter le trajet maintenant | Active l'arrêt manuel immédiat du trajet en cours |
+
+---
+
+## Sensors (23+ entités)
+
+### Trigger Sensors
+
+Ces sensors se mettent à jour automatiquement via des triggers (changements d'état ou intervalles de temps).
+
+| Entity ID | Nom | Unité | Device Class | State Class | Description |
+|-----------|-----|-------|--------------|-------------|-------------|
+| `sensor.scooter_start_time_iso` | Scooter - Heure de départ ISO | - | - | - | Heure de départ au format ISO 8601 |
+| `sensor.scooter_history_start` | Scooter - History Start | - | - | - | Format relatif pour carte historique ("X hours ago") |
+| `sensor.scooter_trip_status` | Scooter - État du trajet | - | - | - | État du trajet actuel (on/off) |
+| `sensor.scooter_active_trip_duration` | Scooter - Durée du trajet en cours | minutes | - | - | Durée du trajet actif mis à jour chaque minute |
+| `sensor.scooter_energy_consumption` | Scooter - Consommation d'énergie | kWh | energy | total_increasing | Consommation totale d'énergie cumulée |
+
+> **Sensor critique**: `sensor.scooter_energy_consumption` calcule automatiquement la consommation nette (déchargée - régénérée) avec validation anti-rebond (max 5.6 kWh/variation).
+
+---
+
+### Template Sensors
+
+Ces sensors utilisent des templates Jinja2 pour calculer leur valeur.
+
+| Entity ID | Nom | Unité | Description |
+|-----------|-----|-------|-------------|
+| `sensor.scooter_status_display` | Scooter - Status | - | Affichage textuel du statut du scooter (Éteint, Prêt à conduire, En mouvement, etc.) |
+| `sensor.scooter_estimated_range` | Scooter - Autonomie estimée | km | Autonomie calculée basée sur consommation moyenne |
+| `sensor.scooter_battery_status` | Scooter - Battery Status | - | État de présence de la batterie (Présente/Absente) |
+| `sensor.scooter_battery_per_km` | Scooter - Consommation par km | %/km | Consommation moyenne de batterie par kilomètre |
+| `sensor.scooter_is_moving` | Scooter - En mouvement | - | Indicateur de mouvement (on/off) basé sur statut et dernière MAJ |
+| `sensor.scooter_end_time_relative` | Scooter - Dernier trajet | - | Temps relatif depuis le dernier trajet ("Il y a X") |
+
+---
+
+### Energy Cost Sensors
+
+Ces sensors calculent automatiquement les coûts énergétiques basés sur le tarif configuré.
+
+| Entity ID | Nom | Unité | State Class | Description |
+|-----------|-----|-------|-------------|-------------|
+| `sensor.scooter_energy_cost_daily` | Scooter - Coût quotidien de la recharge | € | measurement | Coût énergétique du jour |
+| `sensor.scooter_energy_cost_weekly` | Scooter - Coût hebdo de la recharge | € | measurement | Coût énergétique de la semaine |
+| `sensor.scooter_energy_cost_monthly` | Scooter - Coût mensuel de la recharge | € | measurement | Coût énergétique du mois |
+| `sensor.scooter_energy_cost_yearly` | Scooter - Coût annuel de la recharge | € | measurement | Coût énergétique de l'année |
+
+> **Note**: Le tarif par défaut est 0.215 €/kWh mais peut être personnalisé via le paramètre `tariff_sensor` de la configuration.
+
+---
+
+### Battery Health Sensors
+
+Ces sensors surveillent la santé de la batterie.
+
+| Entity ID | Nom | Unité | State Class | Device Class | Description |
+|-----------|-----|-------|-------------|--------------|-------------|
+| `sensor.scooter_battery_cell_imbalance` | Batterie - Déséquilibre cellules | mV | measurement | - | Différence de tension entre la cellule la plus haute et la plus basse |
+| `sensor.scooter_battery_soc_calculated` | Batterie - SOC calculé (Voltage) | % | measurement | battery | SOC calculé à partir de la tension (46.2V-58.8V pour batterie 14S) |
+| `sensor.scooter_battery_soc_deviation` | Batterie - Écart SOC affiché/calculé | % | measurement | - | Différence entre SOC affiché et SOC calculé par tension |
+| `sensor.scooter_battery_charge_cycles` | Batterie - Cycles de charge cumulés | cycles | total_increasing | - | Nombre de cycles équivalents complets (charged_energy / 5.6 kWh) |
+
+> **Déséquilibre critique**: Un déséquilibre > 100 mV entre cellules peut indiquer un problème de BMS ou de cellule défaillante.
+
+---
+
+### Usage Statistics Sensors
+
+Ces sensors fournissent des statistiques d'utilisation.
+
+| Entity ID | Nom | Unité | State Class | Description |
+|-----------|-----|-------|-------------|-------------|
+| `sensor.scooter_distance_per_charge` | Utilisation - Distance par charge | km | measurement | Distance moyenne par cycle de charge complet |
+| `sensor.scooter_cost_per_km` | Utilisation - Coût au kilomètre | €/km | measurement | Coût moyen par kilomètre parcouru |
+| `sensor.scooter_average_trip_distance` | Utilisation - Distance moyenne par trajet | km | measurement | Distance moyenne calculée sur l'historique des trajets |
+
+---
+
+### Utility Meters
+
+Ces sensors sont des compteurs qui se réinitialisent automatiquement selon leur cycle.
+
+| Entity ID | Nom | Cycle | Source | Description |
+|-----------|-----|-------|--------|-------------|
+| `sensor.scooter_energy_consumption_daily` | Scooter Energy Consumption Daily | daily | `sensor.scooter_energy_consumption` | Consommation journalière (reset à minuit) |
+| `sensor.scooter_energy_consumption_weekly` | Scooter Energy Consumption Weekly | weekly | `sensor.scooter_energy_consumption` | Consommation hebdomadaire (reset le lundi) |
+| `sensor.scooter_energy_consumption_monthly` | Scooter Energy Consumption Monthly | monthly | `sensor.scooter_energy_consumption` | Consommation mensuelle (reset le 1er) |
+| `sensor.scooter_energy_consumption_yearly` | Scooter Energy Consumption Yearly | yearly | `sensor.scooter_energy_consumption` | Consommation annuelle (reset le 1er janvier) |
+
+> **Note**: Ces compteurs peuvent être restaurés manuellement via le service `silencescooter.restore_energy_costs`.
+
+---
+
+### Writable Sensors
+
+Ces sensors spéciaux peuvent être modifiés par l'intégration et conservent leur valeur même quand le scooter est hors ligne.
+
+| Entity ID | Nom | Unité | Device Class | State Class | Description |
+|-----------|-----|-------|--------------|-------------|-------------|
+| `sensor.scooter_battery_display` | Niveau de batterie | % | battery | measurement | Affichage persistant du niveau de batterie |
+| `sensor.scooter_odo_display` | Odomètre | km | - | total_increasing | Affichage persistant de l'odomètre |
+| `sensor.scooter_battery_percentage_regeneration` | Pourcentage énergie régénérée | % | - | measurement | % d'énergie régénérée par freinage (regenerated / (discharged + regenerated)) |
+
+> **Persistance**: Ces sensors conservent leur dernière valeur connue même quand le scooter est éteint ou déconnecté, pour un affichage continu dans Home Assistant.
+
+---
+
+## Voir aussi
+
+- [Structure du fichier history.json](HISTORY.md)
+- [Configuration de l'intégration](CONFIGURATION.md)
+- [Guide de débogage](DEBUGGING.md)

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -1,0 +1,268 @@
+# Structure du fichier history.json
+
+Cette page documente la structure et le contenu du fichier `history.json` qui stocke l'historique des trajets de votre scooter.
+
+## Emplacement
+
+Le fichier est situé à :
+```
+/config/custom_components/silencescooter/data/history.json
+```
+
+## Structure générale
+
+Le fichier contient un tableau JSON où chaque élément représente un trajet. Les trajets sont stockés dans l'ordre **anti-chronologique** (le plus récent en premier).
+
+```json
+[
+  { "trajet le plus récent" },
+  { "trajet précédent" },
+  { "..." }
+]
+```
+
+## Structure d'un trajet
+
+Chaque trajet contient les champs suivants :
+
+| Champ | Type | Unité | Description |
+|-------|------|-------|-------------|
+| `start_time` | string (ISO 8601) | - | Date et heure de début du trajet |
+| `end_time` | string (ISO 8601) | - | Date et heure de fin du trajet |
+| `duration` | string (number) | minutes | Durée nette du trajet (hors pauses) |
+| `distance` | string (number) | km | Distance parcourue |
+| `avg_speed` | string (number) | km/h | Vitesse moyenne |
+| `max_speed` | string (number) | km/h | Vitesse maximale atteinte |
+| `battery` | string (number) | % | Batterie consommée pendant le trajet |
+| `outdoor_temp` | string (number) | °C | Température extérieure pendant le trajet |
+| `efficiency_wh_km` | string (number) | Wh/km | Efficacité énergétique (calculée automatiquement) |
+
+### Calcul de l'efficacité
+
+L'efficacité énergétique est calculée automatiquement par le script `history.sh` selon la formule :
+
+```
+Efficacité (Wh/km) = (Battery% / 100 × 5600 Wh) / Distance (km)
+```
+
+> **Note**: La capacité de la batterie est de 5.6 kWh (5600 Wh).
+
+## Exemple de fichier complet
+
+Voici un exemple de fichier `history.json` contenant 3 trajets :
+
+```json
+[
+  {
+    "start_time": "2025-11-06T14:30:15+01:00",
+    "end_time": "2025-11-06T14:52:38+01:00",
+    "duration": "20",
+    "distance": "8.3",
+    "avg_speed": "24.9",
+    "max_speed": "48.5",
+    "battery": "18.2",
+    "outdoor_temp": "16.5",
+    "efficiency_wh_km": "122.9"
+  },
+  {
+    "start_time": "2025-11-06T09:15:42+01:00",
+    "end_time": "2025-11-06T09:28:10+01:00",
+    "duration": "10",
+    "distance": "3.7",
+    "avg_speed": "22.2",
+    "max_speed": "42.0",
+    "battery": "8.5",
+    "outdoor_temp": "12.8",
+    "efficiency_wh_km": "128.6"
+  },
+  {
+    "start_time": "2025-11-05T18:05:20+01:00",
+    "end_time": "2025-11-05T18:35:45+01:00",
+    "duration": "28",
+    "distance": "12.1",
+    "avg_speed": "25.9",
+    "max_speed": "51.2",
+    "battery": "24.8",
+    "outdoor_temp": "14.2",
+    "efficiency_wh_km": "114.9"
+  }
+]
+```
+
+## Exemple de trajet détaillé
+
+Analysons un trajet en détail :
+
+```json
+{
+  "start_time": "2025-11-06T14:30:15+01:00",
+  "end_time": "2025-11-06T14:52:38+01:00",
+  "duration": "20",
+  "distance": "8.3",
+  "avg_speed": "24.9",
+  "max_speed": "48.5",
+  "battery": "18.2",
+  "outdoor_temp": "16.5",
+  "efficiency_wh_km": "122.9"
+}
+```
+
+### Interprétation
+
+- **Trajet effectué le** : 6 novembre 2025
+- **Heure de départ** : 14h30:15
+- **Heure d'arrivée** : 14h52:38
+- **Durée totale écoulée** : ~22 minutes
+- **Durée nette** : 20 minutes (2 minutes de pauses cumulées)
+- **Distance** : 8.3 km
+- **Vitesse moyenne** : 24.9 km/h (sur la durée nette de 20 min)
+- **Vitesse max** : 48.5 km/h
+- **Batterie consommée** : 18.2%
+- **Température** : 16.5°C
+- **Efficacité** : 122.9 Wh/km (soit ~1019 Wh consommés pour ce trajet)
+
+### Vérification de cohérence
+
+On peut vérifier la cohérence des données :
+
+1. **Vitesse moyenne** = Distance / Durée = 8.3 km / (20 min / 60) = 24.9 km/h ✓
+2. **Énergie consommée** = 18.2% × 5.6 kWh = 1.019 kWh = 1019 Wh
+3. **Efficacité** = 1019 Wh / 8.3 km = 122.8 Wh/km ≈ 122.9 Wh/km ✓
+
+## Validation des trajets
+
+L'intégration effectue plusieurs validations avant d'enregistrer un trajet dans l'historique :
+
+### Validations automatiques
+
+1. **Durée minimale** : Rejet si `duration < 1.5 min` ET `distance > 2 km` (physiquement impossible)
+2. **Vitesse maximale** : Rejet si `avg_speed > 120 km/h` (dépassement limite scooter)
+3. **Cohérence vitesse** : Rejet si écart > 30% entre vitesse calculée et enregistrée
+4. **Vitesse max cohérente** : Rejet si `max_speed = 0` alors que `avg_speed > 10 km/h`
+
+### Exemple de trajet rejeté
+
+```
+⚠️ TRIP REJECTED - Data validation failed:
+  - Trip too short: 0.8 min for 5.2 km
+  - Speed inconsistency: calculated=390.0 vs recorded=24.9
+Trip data: distance=5.2 km, duration=0.8 min, avg_speed=24.9 km/h, battery=5.2%
+```
+
+## Accéder aux données depuis Home Assistant
+
+### Via sensor
+
+Le sensor `sensor.scooter_trips` expose l'historique complet dans son attribut `history` :
+
+```yaml
+{{ state_attr('sensor.scooter_trips', 'history') }}
+```
+
+### Via template
+
+Vous pouvez extraire des statistiques avec des templates :
+
+```yaml
+# Nombre total de trajets
+{{ state_attr('sensor.scooter_trips', 'history') | length }}
+
+# Distance totale parcourue
+{{ state_attr('sensor.scooter_trips', 'history') | map(attribute='distance') | map('float') | sum }}
+
+# Efficacité moyenne
+{% set trips = state_attr('sensor.scooter_trips', 'history') %}
+{{ (trips | map(attribute='efficiency_wh_km') | map('float') | sum / trips | length) | round(1) }}
+```
+
+### Via Lovelace
+
+Utilisez l'exemple de dashboard fourni (`examples/lovelace_silence.yaml`) qui affiche l'historique sous forme de tableau.
+
+## Maintenance du fichier
+
+### Sauvegarde
+
+Nous recommandons de sauvegarder régulièrement le fichier :
+
+```bash
+cp /config/custom_components/silencescooter/data/history.json \
+   /config/backups/history_$(date +%Y%m%d).json
+```
+
+### Nettoyage
+
+Pour supprimer les anciens trajets (> 6 mois) :
+
+```bash
+jq '[.[] | select(
+  (.start_time | fromdateiso8601) > (now - 15552000)
+)]' history.json > history_cleaned.json
+mv history_cleaned.json history.json
+```
+
+### Réinitialisation
+
+Pour repartir avec un historique vide :
+
+```bash
+echo "[]" > /config/custom_components/silencescooter/data/history.json
+```
+
+## Format des dates
+
+Les dates utilisent le format **ISO 8601** avec timezone :
+
+```
+YYYY-MM-DDTHH:MM:SS+TZ:TZ
+```
+
+Exemples :
+- `2025-11-06T14:30:15+01:00` (heure d'hiver Europe/Paris)
+- `2025-07-15T14:30:15+02:00` (heure d'été Europe/Paris)
+
+> **Important** : Le timezone est toujours inclus pour éviter les ambiguïtés.
+
+## Troubleshooting
+
+### Le fichier est vide ou corrompu
+
+Si le fichier est vide (`[]`) ou corrompu, l'intégration le réinitialisera automatiquement au prochain trajet.
+
+### Les trajets ne s'enregistrent pas
+
+1. Vérifiez les permissions du fichier :
+   ```bash
+   ls -l /config/custom_components/silencescooter/data/history.json
+   ```
+
+2. Vérifiez les logs Home Assistant :
+   ```
+   grep "update_history" /config/home-assistant.log
+   ```
+
+3. Vérifiez que le script bash existe :
+   ```bash
+   ls -l /config/custom_components/silencescooter/scripts/history.sh
+   ```
+
+### Format JSON invalide
+
+Validez manuellement le fichier :
+
+```bash
+jq . /config/custom_components/silencescooter/data/history.json
+```
+
+Si erreur, sauvegardez et réinitialisez :
+
+```bash
+cp history.json history.json.backup
+echo "[]" > history.json
+```
+
+## Voir aussi
+
+- [Liste complète des entités](ENTITIES.md)
+- [Guide de configuration](CONFIGURATION.md)
+- [Guide de débogage](DEBUGGING.md)


### PR DESCRIPTION
- docs/ENTITIES.md: Complete list of all 39+ entities exposed by the integration
  - 11 Numbers (odometer, battery, trip metrics)
  - 4 DateTimes (trip timestamps, pause tracking)
  - 1 Switch (manual trip stop)
  - 23+ Sensors (energy, costs, battery health, statistics)

- docs/HISTORY.md: Detailed trip history structure documentation
  - JSON file structure and location
  - Complete field descriptions with units
  - Real-world trip example with interpretation
  - Energy efficiency calculation formula
  - Trip validation rules
  - Maintenance and troubleshooting guides

- README.md: Updated to reference new documentation
  - Enhanced "Entities Created" section with summary table
  - Added direct links to ENTITIES.md and HISTORY.md
  - Highlighted 39+ entities count